### PR TITLE
Fix activation/deactivation hooks registering

### DIFF
--- a/.changeset/chilly-terms-destroy.md
+++ b/.changeset/chilly-terms-destroy.md
@@ -1,0 +1,5 @@
+---
+"frontity-headtags": patch
+---
+
+Fix the registering of activation / deactivation hooks.

--- a/shared/class-frontity-plugin.php
+++ b/shared/class-frontity-plugin.php
@@ -65,6 +65,13 @@ abstract class Frontity_Plugin {
 	}
 
 	/**
+	 * Get the main PHP file.
+	 */
+	public static function get_main_php_file() {
+		return static::get_path() . 'plugin.php';
+	}
+
+	/**
 	 * Get the plugin dir URL.
 	 */
 	public static function get_url() {
@@ -75,7 +82,7 @@ abstract class Frontity_Plugin {
 	 * Get the plugin version.
 	 */
 	public static function get_version() {
-		return get_plugin_data( static::get_path() . 'plugin.php', false, false )['Version'];
+		return get_plugin_data( static::get_main_php_file(), false, false )['Version'];
 	}
 
 	/**
@@ -238,8 +245,8 @@ abstract class Frontity_Plugin {
 
 		add_action( 'init', array( $instance, 'should_run' ) );
 
-		register_activation_hook( static::get_file_name(), array( $instance, 'activate' ) );
-		register_deactivation_hook( static::get_file_name(), array( $instance, 'deactivate' ) );
+		register_activation_hook( static::get_main_php_file(), array( $instance, 'activate' ) );
+		register_deactivation_hook( static::get_main_php_file(), array( $instance, 'deactivate' ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes a bug during the activation/deactivation hooks registering that was preventing `activate` and `deactivate` methods to be called.

That registering logic was moved to a static method named `install`, in `/shared/class-frontity-plugin.php`, but it was using a wrong file name when calling `register_activation_hook` and `register_deactivation_hook` functions. The file that should be used is the one with the plugin description (i.e. `/plugins/PLUGIN_NAME/plugin.php`)