### PR TITLE
Call 'template_redirect' action without redirecting

### DIFF
--- a/.changeset/violet-shirts-draw.md
+++ b/.changeset/violet-shirts-draw.md
@@ -1,0 +1,5 @@
+---
+"frontity-headtags": patch
+---
+
+Fix redirects when making calls to the REST API

--- a/plugins/frontity-headtags/includes/class-frontity-headtags.php
+++ b/plugins/frontity-headtags/includes/class-frontity-headtags.php
@@ -138,8 +138,12 @@ class Frontity_Headtags {
 
 		ob_start();
 		
+		// Arguments to be used when doing 'template_redirect' action.
+		$requested_url = null;
+		$do_redirect   = false;
+
 		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-		do_action( 'template_redirect' );
+		do_action( 'template_redirect', $requested_url, $do_redirect );
 		do_action( 'wp_head' );
 		// phpcs:enable
 
@@ -249,6 +253,10 @@ class Frontity_Headtags {
 		$wp_the_query = $new_query;
 		// phpcs:enable
 
+		// Allow 'redirect_canonical' action to receive arguments.
+		remove_action( 'template_redirect', 'redirect_canonical' );
+		add_action( 'template_redirect', 'redirect_canonical', 10, 2 );
+
 		// Init integrations.
 		do_action( 'frontity_headtags_replace_query' );
 	}
@@ -266,6 +274,10 @@ class Frontity_Headtags {
 		$wp_the_query = $backup['wp_the_query'];
 		// phpcs:enable
 		wp_reset_postdata();
+
+		// Reset 'redirect_canonical' action.
+		remove_action( 'template_redirect', 'redirect_canonical', 10, 2 );
+		add_action( 'template_redirect', 'redirect_canonical' );
 
 		// Reset integrations.
 		do_action( 'frontity_headtags_restore_query' );

--- a/plugins/frontity-headtags/includes/class-frontity-headtags.php
+++ b/plugins/frontity-headtags/includes/class-frontity-headtags.php
@@ -257,6 +257,9 @@ class Frontity_Headtags {
 		remove_action( 'template_redirect', 'redirect_canonical' );
 		add_action( 'template_redirect', 'redirect_canonical', 10, 2 );
 
+		// Remove 'rest_output_link_header' action.
+		remove_action( 'template_redirect', 'rest_output_link_header', 11, 0 );
+
 		// Init integrations.
 		do_action( 'frontity_headtags_replace_query' );
 	}
@@ -279,6 +282,9 @@ class Frontity_Headtags {
 		remove_action( 'template_redirect', 'redirect_canonical', 10, 2 );
 		add_action( 'template_redirect', 'redirect_canonical' );
 
+		// Reset 'rest_output_link_header' action.
+		add_action( 'template_redirect', 'rest_output_link_header', 11, 0 );
+		
 		// Reset integrations.
 		do_action( 'frontity_headtags_restore_query' );
 	}


### PR DESCRIPTION
This PR adds arguments to the `template_redirect` hook call and changes how the `redirect_canonical` callback is registered in order to avoid a `301` response when doing a REST API request.

Fixes #20 

