### PR TITLE
Use correct actions in setup_hooks

### DIFF
--- a/.changeset/wise-meals-stare.md
+++ b/.changeset/wise-meals-stare.md
@@ -1,0 +1,8 @@
+---
+"frontity-headtags": patch
+---
+
+Fix the way admin hooks and rest api hooks are being registered.
+
+- `admin_init` is used for `register_admin_hooks`
+- `rest_api_init` is used for `register_rest_hooks`

--- a/plugins/frontity-headtags/class-frontity-headtags-plugin.php
+++ b/plugins/frontity-headtags/class-frontity-headtags-plugin.php
@@ -74,13 +74,13 @@ class Frontity_Headtags_Plugin extends Frontity_Plugin {
 
 		// Init hooks.
 		if ( is_admin() ) {
-			add_action( 'admin_init', array( $post_types, 'register_admin_hooks' ) );
-			add_action( 'admin_init', array( $taxonomies, 'register_admin_hooks' ) );
-			add_action( 'admin_init', array( $authors, 'register_admin_hooks' ) );
+			add_action( 'admin_init', array( $post_types, 'register_admin_hooks' ), 50 );
+			add_action( 'admin_init', array( $taxonomies, 'register_admin_hooks' ), 50 );
+			add_action( 'admin_init', array( $authors, 'register_admin_hooks' ), 50 );
 		} elseif ( $this->is_enabled() ) {
-			add_action( 'rest_api_init', array( $post_types, 'register_rest_hooks' ) );
-			add_action( 'rest_api_init', array( $taxonomies, 'register_rest_hooks' ) );
-			add_action( 'rest_api_init', array( $authors, 'register_rest_hooks' ) );
+			add_action( 'rest_api_init', array( $post_types, 'register_rest_hooks' ), 50 );
+			add_action( 'rest_api_init', array( $taxonomies, 'register_rest_hooks' ), 50 );
+			add_action( 'rest_api_init', array( $authors, 'register_rest_hooks' ), 50 );
 		}
 
 		// Add AJAX action hooks.

--- a/plugins/frontity-headtags/class-frontity-headtags-plugin.php
+++ b/plugins/frontity-headtags/class-frontity-headtags-plugin.php
@@ -74,13 +74,13 @@ class Frontity_Headtags_Plugin extends Frontity_Plugin {
 
 		// Init hooks.
 		if ( is_admin() ) {
-			$post_types->register_admin_hooks();
-			$taxonomies->register_admin_hooks();
-			$authors->register_admin_hooks();
+			add_action( 'admin_init', array( $post_types, 'register_admin_hooks' ) );
+			add_action( 'admin_init', array( $taxonomies, 'register_admin_hooks' ) );
+			add_action( 'admin_init', array( $authors, 'register_admin_hooks' ) );
 		} elseif ( $this->is_enabled() ) {
-			$post_types->register_rest_hooks();
-			$taxonomies->register_rest_hooks();
-			$authors->register_rest_hooks();
+			add_action( 'rest_api_init', array( $post_types, 'register_rest_hooks' ) );
+			add_action( 'rest_api_init', array( $taxonomies, 'register_rest_hooks' ) );
+			add_action( 'rest_api_init', array( $authors, 'register_rest_hooks' ) );
 		}
 
 		// Add AJAX action hooks.


### PR DESCRIPTION
This PR fixes the way admin hooks and rest api hooks are being registered.

- `admin_init` is used for `register_admin_hooks`
- `rest_api_init` is used for `register_rest_hooks`

Fixes #18 