### PR TITLE
Do not call `template_redirect` in Head Tags plugin

### DIFF
--- a/.changeset/violet-birds-look.md
+++ b/.changeset/violet-birds-look.md
@@ -1,0 +1,5 @@
+---
+"frontity-headtags": patch
+---
+
+Fix redirects to images when making calls to the REST API in a site with Yoast installed. Also, refactor the code to prevent other redirections in the future.

--- a/plugins/frontity-headtags/includes/class-frontity-headtags.php
+++ b/plugins/frontity-headtags/includes/class-frontity-headtags.php
@@ -120,13 +120,14 @@ class Frontity_Headtags {
 		$requested_url = null;
 		$do_redirect   = false;
 
-		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-		do_action( 'template_redirect', $requested_url, $do_redirect );
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		do_action( 'wp_head' );
-		// phpcs:enable
 
 		// Get rendered <head> content.
 		$html = ob_get_clean();
+
+		// Filter the <head> HTML code.
+		$html = apply_filters( 'frontity_headtags_html', $html );
 
 		// Parse the HTML to create an array of head tags.
 		$headtags = $this->parse( $html );

--- a/plugins/frontity-headtags/includes/integrations/class-frontity-headtags-aioseo.php
+++ b/plugins/frontity-headtags/includes/integrations/class-frontity-headtags-aioseo.php
@@ -30,6 +30,31 @@ class Frontity_Headtags_AIOSEO {
 			define( 'AIOSEOP_UNIT_TESTING', true );
 		}
 
+		// Run AIOSEOP logic.
+		// This code is based on the `template_redirect` method of the
+		// `All_in_One_SEO_Pack` class (aioseop_class.php).
+		global $aiosp, $aioseop_options;
+
+		// Change title if page is included.
+		$aiosp->get_queried_object();
+		if ( $aiosp->is_page_included() ) {
+			// Get `force_rewrites` value from AIOSEOP options.
+			$force_rewrites = isset( $aioseop_options['aiosp_force_rewrites'] )
+				? $aioseop_options['aiosp_force_rewrites']
+				: 1;
+	
+			// Add the appropriate filter to change the title.
+			if ( $force_rewrites ) {
+				// NOTE: the AIOSEOP plugin uses `ob_start` in this line, passing a 
+				// callback that replaces the title at the end of the PHP call.
+				// Here, that callback is passed to a filter that runs when the <head>
+				// content is computed.
+				add_filter( 'frontity_headtags_html', array( $aiosp, 'rewrite_title' ) );
+			} else {
+				add_filter( 'wp_title', array( $aiosp, 'wp_title' ), 20 );
+			}
+		}
+
 		// The WP Query has changed at this moment, we can check if it's for an author.
 		global $wp_query;
 
@@ -44,6 +69,11 @@ class Frontity_Headtags_AIOSEO {
 	 * Reset function.
 	 */
 	public function reset() {
+		// Remove AIOSEOP filters (if they were added).
+		global $aiosp;
+		remove_filter( 'frontity_headtags_html', array( $aiosp, 'rewrite_title' ) );
+		remove_filter( 'wp_title', array( $aiosp, 'wp_title' ), 20 );
+
 		// Remove the ld+json filter if it was added.
 		remove_filter( 'frontity_headtags_result', array( $this, 'filter_ldjson' ) );
 	}

--- a/plugins/frontity-headtags/includes/integrations/class-frontity-headtags-yoast.php
+++ b/plugins/frontity-headtags/includes/integrations/class-frontity-headtags-yoast.php
@@ -26,6 +26,9 @@ class Frontity_Headtags_Yoast {
 	public function setup() {
 		// Create a new instance of WPSEO_Frontend if it's not created yet.
 		WPSEO_Frontend::get_instance();
+
+		// Call Yoast init function.
+		wpseo_frontend_head_init();
 	}
 
 	/**


### PR DESCRIPTION
SEO plugins register hooks to the `template_redirect` action to add or modify tags inside the `<head>`, so it was useful to launch this action before `wp_head`. Not anymore, as some plugins are calling `wp_redirect` for certain elements (like images).

This PR removes the `template_redirect` action call and refactor the current integrations to move the stuff they were doing in `template_redirect` to the `frontity_headtags_replace_query` action.

Changes were tested against three different sites, each of them with a specific SEO plugin ([Yoast SEO](https://wordpress.org/plugins/wordpress-seo/), [All In One SEO Pack](https://wordpress.org/plugins/all-in-one-seo-pack/) and [WP SEO](https://github.com/alleyinteractive/wp-seo)).