### PR TITLE
Fix phpunit github action

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,8 +9,6 @@ jobs:
     services:
       mysql:
         image: mysql:5.7.27
-        ports:
-          - 3306
         env:
           MYSQL_ROOT_PASSWORD: root
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,8 +13,6 @@ jobs:
           - 3306
         env:
           MYSQL_ROOT_PASSWORD: root
-        volumes:
-          - mysql:/var/lib/mysql
 
     strategy:
       matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
         volumes:
-          - /$(pwd)/mysql:/var/lib/mysql
+          - ./mysql:/var/lib/mysql
 
     strategy:
       matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   phpunit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     services:
       mysql:
@@ -14,7 +14,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
         volumes:
-          - /$HOME/mysql:/var/lib/mysql
+          - $HOME/mysql:/var/lib/mysql
 
     strategy:
       matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
         volumes:
-          - /$HOME/mysql:/var/lib/mysql
+          - $(pwd)/mysql:/var/lib/mysql
 
     strategy:
       matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
         volumes:
-          - $(pwd)/mysql:/var/lib/mysql
+          - /$(pwd)/mysql:/var/lib/mysql
 
     strategy:
       matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,7 +10,7 @@ jobs:
       mysql:
         image: mysql:5.7.27
         ports:
-          - 3306
+          - 3306:3306
         env:
           MYSQL_ROOT_PASSWORD: root
 
@@ -35,9 +35,7 @@ jobs:
         run: composer install
 
       - name: Install WordPress
-        run: ./bin/install-wp-tests.sh frontity_tests root root "127.0.0.1:$PORT" latest
-        env:
-          PORT: ${{ job.services.mysql.ports[3306] }}
+        run: ./bin/install-wp-tests.sh frontity_tests root root 127.0.0.1 latest
 
       - name: Run phpunit
         run: composer phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   phpunit-tests:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     services:
       mysql:
@@ -14,7 +14,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
         volumes:
-          - $HOME/mysql:/var/lib/mysql
+          - /$HOME/mysql:/var/lib/mysql
 
     strategy:
       matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
         volumes:
-          - $HOME/mysql/var/lib/mysql
+          - /$HOME/mysql:/var/lib/mysql
 
     strategy:
       matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
         volumes:
-          - ./mysql:/var/lib/mysql
+          - mysql:/var/lib/mysql
 
     strategy:
       matrix:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -35,7 +35,7 @@ jobs:
         run: composer install
 
       - name: Install WordPress
-        run: ./bin/install-wp-tests.sh frontity_tests root root 127.0.0.1 latest
+        run: ./bin/install-wp-tests.sh frontity_tests root root mysql latest
 
       - name: Run phpunit
         run: composer phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,6 +9,8 @@ jobs:
     services:
       mysql:
         image: mysql:5.7.27
+        ports:
+          - 3306
         env:
           MYSQL_ROOT_PASSWORD: root
 
@@ -33,7 +35,9 @@ jobs:
         run: composer install
 
       - name: Install WordPress
-        run: ./bin/install-wp-tests.sh frontity_tests root root mysql latest
+        run: ./bin/install-wp-tests.sh frontity_tests root root "127.0.0.1:$PORT" latest
+        env:
+          PORT: ${{ job.services.mysql.ports[3306] }}
 
       - name: Run phpunit
         run: composer phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
         volumes:
-          - $HOME/mysql:/var/lib/mysql
+          - $HOME/mysql/var/lib/mysql
 
     strategy:
       matrix:


### PR DESCRIPTION
This PR fixes the following error when running the phpunit action:

```
Error response from daemon: create $HOME/mysql: "$HOME/mysql" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path
```