### PR TITLE
Update class-frontity-headtags.php

### DIFF
--- a/.changeset/poor-planes-behave.md
+++ b/.changeset/poor-planes-behave.md
@@ -1,0 +1,5 @@
+---
+"frontity-headtags": patch
+---
+
+Return an empty array when there is no `<head>` tag.

--- a/plugins/frontity-headtags/includes/class-frontity-headtags.php
+++ b/plugins/frontity-headtags/includes/class-frontity-headtags.php
@@ -160,7 +160,8 @@ class Frontity_Headtags {
 		libxml_clear_errors();
 		libxml_use_internal_errors( $previous_value );
 
-		$dom_node = $dom->getElementsByTagName( 'head' )[0]; $nodes = $dom_node ? $dom_node->childNodes : [];
+		$dom_node = $dom->getElementsByTagName( 'head' )[0];
+		$nodes    = $dom_node ? $dom_node->childNodes : array();
 		
 		foreach ( $nodes as $node ) {
 

--- a/plugins/frontity-headtags/includes/class-frontity-headtags.php
+++ b/plugins/frontity-headtags/includes/class-frontity-headtags.php
@@ -160,7 +160,7 @@ class Frontity_Headtags {
 		libxml_clear_errors();
 		libxml_use_internal_errors( $previous_value );
 
-		$nodes = $dom->getElementsByTagName( 'head' )[0]->childNodes;
+		$dom_node = $dom->getElementsByTagName( 'head' )[0]; $nodes = $dom_node ? $dom_node->childNodes : [];
 		
 		foreach ( $nodes as $node ) {
 


### PR DESCRIPTION
**What:**
When checking an empty head tag, it will throw an error. 

**Why:**
To fix issue [#44](https://github.com/frontity/wp-plugins/issues/44)

**How:**
We need to add a check to send an empty array if the head tag is empty.

**Tasks:**
- [x]  Add a check for an empty head.